### PR TITLE
Fix crashes in export functions by making indexed_to_raw/2 linear time.

### DIFF
--- a/e3d/e3d_util.erl
+++ b/e3d/e3d_util.erl
@@ -66,8 +66,9 @@ remove_chars([], Max, Acc) ->
 % Functions for meshes stored in indexed format (verts/faces lists)
 %
 indexed_to_raw(Verts, Faces) -> % replace indices with values
+    VertexArray = array:from_list(Verts),
     Make_Raw_Face = fun(Face) ->
-			[lists:nth(Index+1, Verts) || Index <- Face]
+			[array:get(Index, VertexArray) || Index <- Face]
 		    end,
     lists:map(Make_Raw_Face, Faces).
 


### PR DESCRIPTION
Export to STL was crashing for models with large numbers of vertices because the implementation of indexed_to_raw/2 was n^2 in the number of vertices in the model. Fixed indexed_to_raw/2 to be linear by converting the vertex list to an array before the map. Export is now much faster and does not crash.